### PR TITLE
Update playground project to Xcode 14 / Swift 5.7 and iOS 15 targets

### DIFF
--- a/PlaygroundBookv11.3/PlaygroundBook.xcodeproj/project.pbxproj
+++ b/PlaygroundBookv11.3/PlaygroundBook.xcodeproj/project.pbxproj
@@ -499,8 +499,8 @@
 		5E2A7ADD204F611300F4E17A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1110;
-				LastUpgradeCheck = 0930;
+				LastSwiftUpdateCheck = 1410;
+				LastUpgradeCheck = 1410;
 				TargetAttributes = {
 					5E086DBF2051C5A7004D8D25 = {
 						CreatedOnToolsVersion = 9.3;
@@ -522,7 +522,7 @@
 				};
 			};
 			buildConfigurationList = 5E2A7AE0204F611300F4E17A /* Build configuration list for PBXProject "PlaygroundBook" */;
-			compatibilityVersion = "Xcode 11.0";
+			compatibilityVersion = "Xcode 14.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -704,7 +704,7 @@
 				PRODUCT_NAME = "$(PLAYGROUND_BOOK_FILE_NAME)";
 				SKIP_INSTALL = NO;
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 5.7;
 			};
 			name = Debug;
 		};
@@ -719,7 +719,7 @@
 				PRODUCT_NAME = "$(PLAYGROUND_BOOK_FILE_NAME)";
 				SKIP_INSTALL = NO;
 				SUPPORTS_MACCATALYST = YES;
-				SWIFT_VERSION = 5.0;
+				SWIFT_VERSION = 5.7;
 			};
 			name = Release;
 		};
@@ -773,13 +773,13 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 5.1;
+				SWIFT_VERSION = 5.7;
 			};
 			name = Debug;
 		};
@@ -828,12 +828,12 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 5.1;
+				SWIFT_VERSION = 5.7;
 			};
 			name = Release;
 		};

--- a/PlaygroundBookv11.3/README.md
+++ b/PlaygroundBookv11.3/README.md
@@ -15,7 +15,7 @@ In support of this, there are five targets in this Xcode project:
 - **UserModule**: Compiles the *UserModule* user module, a blank user module where users may write code
 - **LiveViewTestApp**: Produces an app which uses the `Book_Sources` module to show the live view similarly to how it would be shown in Swift Playgrounds
 
-This project includes the PlaygroundSupport and PlaygroundBluetooth frameworks from Swift Playgrounds to allow the BookCore, BookAPI, UserModule, and LiveViewTestApp targets to take full advantage of those APIs. The supporting content included with this template, including these frameworks, requires Xcode 11.1 to build. Attempting to use this template with another version of Xcode may result in build errors.
+This project includes the PlaygroundSupport and PlaygroundBluetooth frameworks from Swift Playgrounds to allow the BookCore, BookAPI, UserModule, and LiveViewTestApp targets to take full advantage of those APIs. The supporting content included with this template, including these frameworks, requires Xcode 14.1 to build. Attempting to use this template with another version of Xcode may result in build errors.
 
 For more information about the playground book file format, see the *[Swift Playgrounds authoring documentation](https://developer.apple.com/go/?id=swift-playgroundbook-authoring)*.
 


### PR DESCRIPTION
### Motivation
- Bring the PlaygroundBook Xcode project in `PlaygroundBookv11.3` up to date with the newer Apple template expectations and toolchain.
- Ensure the project uses a modern Swift toolchain and deployment baseline so it builds correctly with current Xcode releases and the provided Swift Playgrounds frameworks.

### Description
- Updated `PlaygroundBookv11.3/PlaygroundBook.xcodeproj/project.pbxproj` to set `compatibilityVersion` to `Xcode 14.0` and bumped `LastSwiftUpdateCheck`/`LastUpgradeCheck` to `1410`.
- Bumped `SWIFT_VERSION` entries to `5.7` across the project build configurations and updated `IPHONEOS_DEPLOYMENT_TARGET` from `12.0` to `15.0` in target configurations.
- Updated `PlaygroundBookv11.3/README.md` to reference the Xcode 14.1 requirement for the bundled Swift Playgrounds frameworks.
- Changes staged and committed with message `Update playground book build settings`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986a6d7490c832eb1b4c1a494912d30)